### PR TITLE
Fix TruffleHog action for push events to main

### DIFF
--- a/.github/workflows/secret-scanning.yml
+++ b/.github/workflows/secret-scanning.yml
@@ -31,12 +31,22 @@ jobs:
         with:
           fetch-depth: 0  # Fetch all history for all branches
 
-      - name: Run TruffleHog
+      - name: Run TruffleHog (Pull Request)
+        if: github.event_name == 'pull_request'
         uses: trufflesecurity/trufflehog@main
         with:
           path: ./
-          base: ${{ github.event.repository.default_branch }}
-          head: HEAD
+          base: ${{ github.event.pull_request.base.sha }}
+          head: ${{ github.event.pull_request.head.sha }}
+          extra_args: --debug --only-verified
+
+      - name: Run TruffleHog (Push)
+        if: github.event_name == 'push'
+        uses: trufflesecurity/trufflehog@main
+        with:
+          path: ./
+          base: ${{ github.event.before }}
+          head: ${{ github.event.after }}
           extra_args: --debug --only-verified
 
   detect-secrets:


### PR DESCRIPTION
Split TruffleHog step into conditional runs:
- On pull_request: scan PR base to head
- On push: scan commits from before to after

This prevents the "BASE and HEAD commits are the same" error that occurs when the action runs on main after a merge, where both base and HEAD would resolve to the same commit.